### PR TITLE
Add height locked switch

### DIFF
--- a/src/components/FoodcubeConfigurator.tsx
+++ b/src/components/FoodcubeConfigurator.tsx
@@ -8,6 +8,7 @@ import useGridState from '@/hooks/useGridState';
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Switch } from "@/components/ui/switch";
 import { Label } from "@/components/ui/label";
+import HeightSwitch from './HeightSwitch';
 import { debugConfiguration } from '@/utils/validation/configDebugger';
 import { createPortal } from 'react-dom';
 import { GridCell } from './types';
@@ -473,6 +474,7 @@ export const FoodcubeConfigurator: React.FC<FoodcubeConfiguratorProps> = ({ vari
             <div className="lg:col-span-5 space-y-3" data-testid="requirements-panel">
               {/* Desktop order (hidden on mobile) */}
               <div className="hidden lg:!block space-y-3">
+                <HeightSwitch />
                 {/* Cladding Key */}
                 <div className="transition-all duration-300 ease-in-out">
                   <CladdingKey requirements={requirements} showDebug={debugMode} />
@@ -502,6 +504,7 @@ export const FoodcubeConfigurator: React.FC<FoodcubeConfiguratorProps> = ({ vari
               
               {/* Mobile order (hidden on desktop) - Preset configs above Cladding Key */}
               <div className="block lg:hidden space-y-3">
+                <HeightSwitch />
                 {/* Preset configurations first */}
                 {hasInteracted && (
                   <div className="bg-white p-3 sm:p-4 rounded-xl shadow-sm border border-gray-100" data-testid="side-presets-mobile">

--- a/src/components/HeightSwitch.tsx
+++ b/src/components/HeightSwitch.tsx
@@ -1,0 +1,20 @@
+import React from 'react'
+import { Switch } from '@/components/ui/switch'
+import { Label } from '@/components/ui/label'
+import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
+
+const HeightSwitch: React.FC = () => (
+  <Tooltip>
+    <TooltipTrigger asChild>
+      <div className="flex items-center justify-end gap-2 text-gray-600">
+        <Switch id="height-switch" checked disabled className="scale-90" />
+        <Label htmlFor="height-switch" className="text-xs">500mm Standard Height</Label>
+      </div>
+    </TooltipTrigger>
+    <TooltipContent side="top" className="text-xs">
+      Only the standard 500mm height is available
+    </TooltipContent>
+  </Tooltip>
+)
+
+export default HeightSwitch


### PR DESCRIPTION
## Summary
- add disabled HeightSwitch component with tooltip
- show height switch in sidebar for desktop and mobile

## Testing
- `npx tsc --noEmit`
- `npm run build`