### PR TITLE
Add preset previews

### DIFF
--- a/src/components/PresetConfigs.tsx
+++ b/src/components/PresetConfigs.tsx
@@ -2,6 +2,91 @@ import React from 'react';
 import { Button } from '@/components/ui/button';
 import { PANEL_COLORS } from '@/constants/colors';
 import { useTutorial } from '@/contexts/TutorialContext';
+import {
+  HoverCard,
+  HoverCardContent,
+  HoverCardTrigger
+} from '@/components/ui/hover-card';
+
+type PresetKey = 'line' | 'l-shape' | 'u-shape' | 'dual-lines';
+
+const PRESET_DIMENSIONS: Record<PresetKey, string> = {
+  'line': '3×1 m',
+  'l-shape': '2×2 m',
+  'u-shape': '3×2 m',
+  'dual-lines': '3×2 m'
+};
+
+const PresetIcon: React.FC<{ preset: PresetKey; size?: number }> = ({
+  preset,
+  size = 24
+}) => {
+  switch (preset) {
+    case 'line':
+      return (
+        <svg
+          width={size}
+          height={size}
+          viewBox="0 0 24 24"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <rect x="2" y="9" width="6" height="6" rx="1" fill={PANEL_COLORS.side} />
+          <rect x="9" y="9" width="6" height="6" rx="1" fill={PANEL_COLORS.side} />
+          <rect x="16" y="9" width="6" height="6" rx="1" fill={PANEL_COLORS.side} />
+        </svg>
+      );
+    case 'l-shape':
+      return (
+        <svg
+          width={size}
+          height={size}
+          viewBox="0 0 24 24"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <rect x="2" y="9" width="6" height="6" rx="1" fill={PANEL_COLORS.side} />
+          <rect x="9" y="9" width="6" height="6" rx="1" fill={PANEL_COLORS.side} />
+          <rect x="9" y="16" width="6" height="6" rx="1" fill={PANEL_COLORS.side} />
+        </svg>
+      );
+    case 'u-shape':
+      return (
+        <svg
+          width={size}
+          height={size}
+          viewBox="0 0 24 24"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <rect x="2" y="9" width="6" height="6" rx="1" fill={PANEL_COLORS.side} />
+          <rect x="2" y="16" width="6" height="6" rx="1" fill={PANEL_COLORS.side} />
+          <rect x="9" y="16" width="6" height="6" rx="1" fill={PANEL_COLORS.side} />
+          <rect x="16" y="16" width="6" height="6" rx="1" fill={PANEL_COLORS.side} />
+          <rect x="16" y="9" width="6" height="6" rx="1" fill={PANEL_COLORS.side} />
+        </svg>
+      );
+    case 'dual-lines':
+      return (
+        <svg
+          width={size}
+          height={size}
+          viewBox="0 0 24 24"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <rect x="2" y="6" width="6" height="5" rx="1" fill={PANEL_COLORS.side} />
+          <rect x="9" y="6" width="6" height="5" rx="1" fill={PANEL_COLORS.side} />
+          <rect x="16" y="6" width="6" height="5" rx="1" fill={PANEL_COLORS.side} />
+          <rect x="2" y="13" width="6" height="5" rx="1" fill={PANEL_COLORS.side} />
+          <rect x="9" y="13" width="6" height="5" rx="1" fill={PANEL_COLORS.side} />
+          <rect x="16" y="13" width="6" height="5" rx="1" fill={PANEL_COLORS.side} />
+        </svg>
+      );
+    default:
+      return null;
+  }
+};
 
 interface PresetConfigsProps {
   onApply: (preset: string) => void;
@@ -23,11 +108,16 @@ export const PresetConfigs: React.FC<PresetConfigsProps> = ({ onApply }) => {
     });
   };
   return (
-    <div className=" justify-center gap-3 sm:gap-4 preset-configs grid grid-cols-2 grid-rows-2" data-testid="preset-configs">
-      <Button 
+    <div
+      className=" justify-center gap-3 sm:gap-4 preset-configs grid grid-cols-2 grid-rows-2"
+      data-testid="preset-configs"
+    >
+      <HoverCard>
+        <HoverCardTrigger asChild>
+          <Button
         variant="outline"
         className="text-xs sm:text-sm md:text-base font-semibold px-3 py-2 sm:px-4 sm:py-3 rounded-xl bg-gradient-to-br from-white to-blue-50 hover:from-blue-50 hover:to-blue-100 transition-all duration-300 border-blue-200 hover:border-blue-400 shadow-md hover:shadow-lg text-blue-900 min-w-[95px] sm:min-w-[120px] md:min-w-[140px] h-[80px] sm:h-[80px] transform hover:scale-105"
-        style={{ 
+        style={{
           boxShadow: '0 4px 15px -2px rgba(18, 159, 206, 0.15), 0 2px 8px -2px rgba(18, 159, 206, 0.1)'
         }}
         onClick={() => handlePresetApply('line')}
@@ -36,17 +126,24 @@ export const PresetConfigs: React.FC<PresetConfigsProps> = ({ onApply }) => {
       >
         <span className="flex flex-col items-center gap-1 sm:gap-2">
           <div className="p-1 rounded-lg bg-white/80 shadow-sm border border-blue-100" style={{ borderColor: `${PANEL_COLORS.side}33` }}>
-            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" className="w-6 h-6 sm:w-7 sm:h-7 md:w-8 md:h-8">
-              <rect x="2" y="9" width="6" height="6" rx="1" fill={PANEL_COLORS.side} />
-              <rect x="9" y="9" width="6" height="6" rx="1" fill={PANEL_COLORS.side} />
-              <rect x="16" y="9" width="6" height="6" rx="1" fill={PANEL_COLORS.side} />
-            </svg>
+            <PresetIcon preset="line" />
           </div>
           <span className="font-medium">Straight (3x1)</span>
+          <span className="text-[10px] text-gray-500">{PRESET_DIMENSIONS['line']}</span>
         </span>
       </Button>
+        </HoverCardTrigger>
+        <HoverCardContent side="top">
+          <div className="flex flex-col items-center gap-1">
+            <PresetIcon preset="line" size={48} />
+            <span className="text-xs text-gray-600">{PRESET_DIMENSIONS['line']}</span>
+          </div>
+        </HoverCardContent>
+      </HoverCard>
       
-      <Button 
+      <HoverCard>
+        <HoverCardTrigger asChild>
+          <Button
         variant="outline"
         className="text-xs sm:text-sm md:text-base font-semibold px-3 py-2 sm:px-4 sm:py-3 rounded-xl bg-gradient-to-br from-white to-blue-50 hover:from-blue-50 hover:to-blue-100 transition-all duration-300 border-blue-200 hover:border-blue-400 shadow-md hover:shadow-lg text-blue-900 min-w-[95px] sm:min-w-[120px] md:min-w-[140px] h-[80px] sm:h-[80px] transform hover:scale-105"
         style={{ 
@@ -58,17 +155,24 @@ export const PresetConfigs: React.FC<PresetConfigsProps> = ({ onApply }) => {
       >
         <span className="flex flex-col items-center gap-1 sm:gap-2">
           <div className="p-1 rounded-lg bg-white/80 shadow-sm border border-blue-100" style={{ borderColor: `${PANEL_COLORS.side}33` }}>
-            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" className="w-6 h-6 sm:w-7 sm:h-7 md:w-8 md:h-8">
-              <rect x="2" y="9" width="6" height="6" rx="1" fill={PANEL_COLORS.side} />
-              <rect x="9" y="9" width="6" height="6" rx="1" fill={PANEL_COLORS.side} />
-              <rect x="9" y="16" width="6" height="6" rx="1" fill={PANEL_COLORS.side} />
-            </svg>
+            <PresetIcon preset="l-shape" />
           </div>
           <span className="font-medium">L-Shape</span>
+          <span className="text-[10px] text-gray-500">{PRESET_DIMENSIONS['l-shape']}</span>
         </span>
       </Button>
+        </HoverCardTrigger>
+        <HoverCardContent side="top">
+          <div className="flex flex-col items-center gap-1">
+            <PresetIcon preset="l-shape" size={48} />
+            <span className="text-xs text-gray-600">{PRESET_DIMENSIONS['l-shape']}</span>
+          </div>
+        </HoverCardContent>
+      </HoverCard>
       
-      <Button 
+      <HoverCard>
+        <HoverCardTrigger asChild>
+          <Button
         variant="outline"
         className="text-xs sm:text-sm md:text-base font-semibold px-3 py-2 sm:px-4 sm:py-3 rounded-xl bg-gradient-to-br from-white to-blue-50 hover:from-blue-50 hover:to-blue-100 transition-all duration-300 border-blue-200 hover:border-blue-400 shadow-md hover:shadow-lg text-blue-900 min-w-[95px] sm:min-w-[120px] md:min-w-[140px] h-[80px] sm:h-[80px] transform hover:scale-105"
         style={{ 
@@ -80,19 +184,24 @@ export const PresetConfigs: React.FC<PresetConfigsProps> = ({ onApply }) => {
       >
         <span className="flex flex-col items-center gap-1 sm:gap-2">
           <div className="p-1 rounded-lg bg-white/80 shadow-sm border border-blue-100" style={{ borderColor: `${PANEL_COLORS.side}33` }}>
-            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" className="w-6 h-6 sm:w-7 sm:h-7 md:w-8 md:h-8">
-              <rect x="2" y="9" width="6" height="6" rx="1" fill={PANEL_COLORS.side} />
-              <rect x="2" y="16" width="6" height="6" rx="1" fill={PANEL_COLORS.side} />
-              <rect x="9" y="16" width="6" height="6" rx="1" fill={PANEL_COLORS.side} />
-              <rect x="16" y="16" width="6" height="6" rx="1" fill={PANEL_COLORS.side} />
-              <rect x="16" y="9" width="6" height="6" rx="1" fill={PANEL_COLORS.side} />
-            </svg>
+            <PresetIcon preset="u-shape" />
           </div>
           <span className="font-medium">U-Shape</span>
+          <span className="text-[10px] text-gray-500">{PRESET_DIMENSIONS['u-shape']}</span>
         </span>
       </Button>
+        </HoverCardTrigger>
+        <HoverCardContent side="top">
+          <div className="flex flex-col items-center gap-1">
+            <PresetIcon preset="u-shape" size={48} />
+            <span className="text-xs text-gray-600">{PRESET_DIMENSIONS['u-shape']}</span>
+          </div>
+        </HoverCardContent>
+      </HoverCard>
       
-      <Button 
+      <HoverCard>
+        <HoverCardTrigger asChild>
+          <Button
         variant="outline"
         className="text-xs sm:text-sm md:text-base font-semibold px-3 py-2 sm:px-4 sm:py-3 rounded-xl bg-gradient-to-br from-white to-blue-50 hover:from-blue-50 hover:to-blue-100 transition-all duration-300 border-blue-200 hover:border-blue-400 shadow-md hover:shadow-lg text-blue-900 min-w-[95px] sm:min-w-[120px] md:min-w-[140px] h-[80px] sm:h-[80px] transform hover:scale-105"
         style={{ 
@@ -104,18 +213,20 @@ export const PresetConfigs: React.FC<PresetConfigsProps> = ({ onApply }) => {
       >
         <span className="flex flex-col items-center gap-1 sm:gap-2">
           <div className="p-1 rounded-lg bg-white/80 shadow-sm border border-blue-100" style={{ borderColor: `${PANEL_COLORS.side}33` }}>
-            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" className="w-6 h-6 sm:w-7 sm:h-7 md:w-8 md:h-8">
-              <rect x="2" y="6" width="6" height="5" rx="1" fill={PANEL_COLORS.side} />
-              <rect x="9" y="6" width="6" height="5" rx="1" fill={PANEL_COLORS.side} />
-              <rect x="16" y="6" width="6" height="5" rx="1" fill={PANEL_COLORS.side} />
-              <rect x="2" y="13" width="6" height="5" rx="1" fill={PANEL_COLORS.side} />
-              <rect x="9" y="13" width="6" height="5" rx="1" fill={PANEL_COLORS.side} />
-              <rect x="16" y="13" width="6" height="5" rx="1" fill={PANEL_COLORS.side} />
-            </svg>
+            <PresetIcon preset="dual-lines" />
           </div>
-          <span className="font-medium">Two Rows</span>
+          <span className="font-medium">Dual Lines</span>
+          <span className="text-[10px] text-gray-500">{PRESET_DIMENSIONS['dual-lines']}</span>
         </span>
       </Button>
+        </HoverCardTrigger>
+        <HoverCardContent side="top">
+          <div className="flex flex-col items-center gap-1">
+            <PresetIcon preset="dual-lines" size={48} />
+            <span className="text-xs text-gray-600">{PRESET_DIMENSIONS['dual-lines']}</span>
+          </div>
+        </HoverCardContent>
+      </HoverCard>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- show dimension labels on each preset
- add hover previews for preset buttons

## Testing
- `npx tsc --noEmit`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685a5bdb3c1083309488d139f3d9f238

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced preset selection with hover popups displaying larger icons and dimensions for each layout option.
- **Style**
	- Updated preset names for consistency and improved the visual presentation of preset buttons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->