### PR TITLE
Fix ESC close for WelcomeModal

### DIFF
--- a/src/components/WelcomeModal.tsx
+++ b/src/components/WelcomeModal.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useRef } from 'react';
 import {
   Dialog,
   DialogContent,
@@ -49,14 +49,35 @@ const EmbeddedModal = ({
 export const WelcomeModal: React.FC = () => {
   const { showWelcomeModal, setShowWelcomeModal, setShowTutorial, skipTutorial } = useTutorial();
   const [mounted, setMounted] = useState(false);
+  const lastFocusedRef = useRef<HTMLElement | null>(null);
 
   // Effect to log visibility state for debugging
   useEffect(() => {
     console.log('WelcomeModal visibility:', showWelcomeModal);
     console.log('Is embedded:', isEmbedded());
-    
+
     setMounted(true);
   }, [showWelcomeModal]);
+
+  // Close on ESC and restore focus to the previously focused element
+  useEffect(() => {
+    if (showWelcomeModal) {
+      lastFocusedRef.current = document.activeElement as HTMLElement;
+      const onKeyDown = (e: KeyboardEvent) => {
+        if (e.key === 'Escape') {
+          setShowWelcomeModal(false);
+        }
+      };
+      document.addEventListener('keydown', onKeyDown);
+      return () => {
+        document.removeEventListener('keydown', onKeyDown);
+      };
+    }
+
+    if (!showWelcomeModal && lastFocusedRef.current) {
+      lastFocusedRef.current.focus();
+    }
+  }, [showWelcomeModal, setShowWelcomeModal]);
 
   const handleStartTutorial = () => {
     setShowWelcomeModal(false);


### PR DESCRIPTION
## Summary
- close WelcomeModal on Escape press
- restore focus to invoking element when closing

## Testing
- `npx tsc --noEmit --pretty false`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685a5bebc7e48330a25eccf0e776fe85

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved accessibility for the Welcome Modal by enabling keyboard navigation and Escape key support.
  - Focus is now automatically restored to the previously focused element when the modal closes, enhancing user experience for keyboard users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->