### PR TITLE
Add undo/redo history

### DIFF
--- a/src/components/FoodcubeConfigurator.tsx
+++ b/src/components/FoodcubeConfigurator.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
+import { Undo2, Redo2 } from 'lucide-react';
 import { HelpTooltip } from './HelpTooltip';
 import { Grid } from './Grid';
 import { PresetConfigs } from './PresetConfigs';
@@ -146,7 +147,7 @@ interface FoodcubeConfiguratorProps {
 
 export const FoodcubeConfigurator: React.FC<FoodcubeConfiguratorProps> = ({ variants, onUpdate, onApply, onClose }) => {
   // console.log('FoodcubeConfigurator received variants:', variants);
-  const { grid, requirements, toggleCell, toggleCladding, applyPreset, error, clearGrid } = useGridState();
+  const { grid, requirements, toggleCell, toggleCladding, applyPreset, error, clearGrid, undo, redo } = useGridState();
   const [hasInteracted, setHasInteracted] = useState(false);
   const [debugMode, setDebugMode] = useState(false); // Default to false for production
   
@@ -179,6 +180,21 @@ export const FoodcubeConfigurator: React.FC<FoodcubeConfiguratorProps> = ({ vari
       debugConfiguration(grid, requirements);
     }
   }, [grid, requirements, debugMode]);
+
+  // Keyboard shortcuts for undo/redo
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if ((e.ctrlKey || e.metaKey) && !e.shiftKey && e.key.toLowerCase() === 'z') {
+        e.preventDefault();
+        undo();
+      } else if ((e.ctrlKey || e.metaKey) && (e.key.toLowerCase() === 'y' || (e.shiftKey && e.key.toLowerCase() === 'z'))) {
+        e.preventDefault();
+        redo();
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [undo, redo]);
 
   // Update the parent component with the current requirements
   React.useEffect(() => {
@@ -357,8 +373,12 @@ export const FoodcubeConfigurator: React.FC<FoodcubeConfiguratorProps> = ({ vari
 
   return (
     <div className="relative w-full mx-auto bg-transparent rounded-xl overflow-hidden backdrop-blur-sm" data-testid="foodcube-configurator">
-      {/* Debug toggle - only visible when debug is enabled */}
-      <div className="absolute top-4 right-4 z-50">
+      {/* Debug toggle and history buttons */}
+      <div className="absolute top-4 right-4 z-50 flex space-x-2">
+        <div className="flex items-center space-x-1 bg-white/90 p-1 rounded-full shadow-sm border border-gray-100">
+          <button onClick={undo} aria-label="Undo" data-testid="undo-button" className="p-1"><Undo2 className="w-4 h-4" /></button>
+          <button onClick={redo} aria-label="Redo" data-testid="redo-button" className="p-1"><Redo2 className="w-4 h-4" /></button>
+        </div>
         {debugMode && (
           <div className="flex items-center space-x-2 bg-white/90 p-1 rounded-full shadow-sm border border-gray-100">
             <Switch

--- a/src/hooks/useGridState.ts
+++ b/src/hooks/useGridState.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect } from 'react';
+import { useState, useCallback, useEffect, useRef } from 'react';
 import { GridCell, Requirements, CompassDirection } from '@/components/types';
 import { calculateRequirements as calculateFlowRequirements } from '@/utils/calculation/requirementsCalculator';
 import { calculateFlowPathPanels } from '@/utils/calculation/panelCalculator';
@@ -78,6 +78,11 @@ const useGridState = () => {
     straightCouplings: 0
   });
 
+  // History stack for undo/redo functionality
+  const historyRef = useRef<GridCell[][][]>([]);
+  const historyIndexRef = useRef(-1);
+  const skipHistoryRef = useRef(false);
+
   const logGridState = (grid: GridCell[][], requirements: Requirements) => {
     // Clear console before logging new state
     console.clear();
@@ -100,6 +105,39 @@ const useGridState = () => {
     console.log('Grid:', gridState);
     console.log('Requirements:', requirements);
     console.groupEnd();
+  };
+
+  // Clone grid to preserve Set structures
+  const cloneGrid = (g: GridCell[][]): GridCell[][] =>
+    g.map(row =>
+      row.map(cell => ({
+        ...cell,
+        claddingEdges: new Set([...cell.claddingEdges]),
+        excludedCladdingEdges: new Set([...cell.excludedCladdingEdges])
+      }))
+    );
+
+  const pushHistory = (g: GridCell[][]) => {
+    const snapshot = cloneGrid(g);
+    historyRef.current = historyRef.current.slice(0, historyIndexRef.current + 1);
+    historyRef.current.push(snapshot);
+    historyIndexRef.current++;
+  };
+
+  const undo = () => {
+    if (historyIndexRef.current <= 0) return;
+    historyIndexRef.current--;
+    skipHistoryRef.current = true;
+    const prevGrid = historyRef.current[historyIndexRef.current];
+    setGrid(cloneGrid(prevGrid));
+  };
+
+  const redo = () => {
+    if (historyIndexRef.current >= historyRef.current.length - 1) return;
+    historyIndexRef.current++;
+    skipHistoryRef.current = true;
+    const nextGrid = historyRef.current[historyIndexRef.current];
+    setGrid(cloneGrid(nextGrid));
   };
 
   const validateAndUpdateGrid = useCallback((newGrid: GridCell[][]) => {
@@ -472,14 +510,22 @@ const useGridState = () => {
     }
   }, [calculateRequirements, validateAndUpdateGrid]);
 
-  // Update requirements whenever the grid changes
+  // Update requirements whenever the grid changes and manage history
+  const isInitialMount = useRef(true);
   useEffect(() => {
-    // Clear console before updating requirements on grid change
     console.clear();
-    
     const newRequirements = calculateRequirements(grid);
     setRequirements(newRequirements);
     logGridState(grid, newRequirements);
+
+    if (isInitialMount.current) {
+      pushHistory(grid);
+      isInitialMount.current = false;
+    } else if (!skipHistoryRef.current) {
+      pushHistory(grid);
+    } else {
+      skipHistoryRef.current = false;
+    }
   }, [grid, calculateRequirements]);
 
   // Function to clear the grid and reset to initial state
@@ -488,7 +534,11 @@ const useGridState = () => {
     // Clear error state
     setError(null);
     // Reset grid to empty state
-    setGrid(initializeGrid());
+    const empty = initializeGrid();
+    setGrid(empty);
+    historyRef.current = [];
+    historyIndexRef.current = -1;
+    pushHistory(empty);
     // Reset requirements
     setRequirements({
       fourPackRegular: 0,
@@ -512,7 +562,9 @@ const useGridState = () => {
     toggleCladding,
     applyPreset,
     error,
-    clearGrid
+    clearGrid,
+    undo,
+    redo
   };
 };
 


### PR DESCRIPTION
## Summary
- add `Undo2` and `Redo2` icons and keyboard shortcuts
- keep history in `useGridState` and expose undo/redo methods
- display undo/redo buttons in configurator

## Testing
- `npx tsc --pretty false`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685a5bc10e2c83309976384afe406fb7