### PR TITLE
Add running subtotal to designer

### DIFF
--- a/src/components/CladdingKey.tsx
+++ b/src/components/CladdingKey.tsx
@@ -94,10 +94,18 @@ interface CladdingKeyProps {
     straightCouplings: number;
     cornerConnectors: number;
   };
+  prices?: {
+    fourPackRegular?: number;
+    fourPackExtraTall?: number;
+    twoPackRegular?: number;
+    twoPackExtraTall?: number;
+    cornerConnectors?: number;
+    straightCouplings?: number;
+  };
   showDebug?: boolean;
 }
 
-export const CladdingKey: React.FC<CladdingKeyProps> = ({ requirements, showDebug = false }) => {
+export const CladdingKey: React.FC<CladdingKeyProps> = ({ requirements, prices, showDebug = false }) => {
   // console.log("CladdingKey received requirements:", JSON.stringify(requirements, null, 2));
   
   // Enhanced logging to track requirements updates
@@ -228,6 +236,18 @@ export const CladdingKey: React.FC<CladdingKeyProps> = ({ requirements, showDebu
   }, [requirements, totalSidePanels, totalLeftPanels, totalRightPanels, configurationType]);
   
   const hasRequirements = Object.values(requirements).some(val => val > 0);
+
+  const subtotal = React.useMemo(() => {
+    if (!prices) return 0;
+    return (
+      (requirements.fourPackRegular * (prices.fourPackRegular || 0)) +
+      (requirements.fourPackExtraTall * (prices.fourPackExtraTall || 0)) +
+      (requirements.twoPackRegular * (prices.twoPackRegular || 0)) +
+      (requirements.twoPackExtraTall * (prices.twoPackExtraTall || 0)) +
+      (requirements.cornerConnectors * (prices.cornerConnectors || 0)) +
+      (requirements.straightCouplings * (prices.straightCouplings || 0))
+    );
+  }, [requirements, prices]);
   
   // Group all products (packages, panels, connectors) into a single list
   const allProducts = [
@@ -473,7 +493,13 @@ export const CladdingKey: React.FC<CladdingKeyProps> = ({ requirements, showDebu
           </div>
         )}
       </div>
-      
+
+      {subtotal > 0 && (
+        <div className="mt-3 text-right font-semibold text-sm" data-testid="subtotal">
+          Subtotal: ${subtotal.toFixed(2)}
+        </div>
+      )}
+
       {/* Debug Info - only shown when explicitly enabled */}
       {showDebug && (
         <details className="mt-2 text-sm border-t border-gray-100 pt-1">

--- a/src/components/FoodcubeConfigurator.tsx
+++ b/src/components/FoodcubeConfigurator.tsx
@@ -149,6 +149,18 @@ export const FoodcubeConfigurator: React.FC<FoodcubeConfiguratorProps> = ({ vari
   const { grid, requirements, toggleCell, toggleCladding, applyPreset, error, clearGrid } = useGridState();
   const [hasInteracted, setHasInteracted] = useState(false);
   const [debugMode, setDebugMode] = useState(false); // Default to false for production
+
+  const prices = React.useMemo(
+    () => ({
+      fourPackRegular: variants?.fourPackRegular?.price ?? 0,
+      fourPackExtraTall: variants?.fourPackExtraTall?.price ?? 0,
+      twoPackRegular: variants?.twoPackRegular?.price ?? 0,
+      twoPackExtraTall: variants?.twoPackExtraTall?.price ?? 0,
+      cornerConnectors: variants?.cornerConnectors?.price ?? 0,
+      straightCouplings: variants?.straightCouplings?.price ?? 0
+    }),
+    [variants]
+  );
   
   // Add tutorial context at component level
   const { showTutorial, setCurrentStep, resetTutorial, resetTutorialState, setShowTutorial } = useTutorial();
@@ -479,7 +491,7 @@ export const FoodcubeConfigurator: React.FC<FoodcubeConfiguratorProps> = ({ vari
               <div className="hidden lg:!block space-y-3">
                 {/* Cladding Key */}
                 <div className="transition-all duration-300 ease-in-out">
-                  <CladdingKey requirements={requirements} showDebug={debugMode} />
+                  <CladdingKey requirements={requirements} prices={prices} showDebug={debugMode} />
                 </div>
                 
                 {/* Preset configurations */}
@@ -529,7 +541,7 @@ export const FoodcubeConfigurator: React.FC<FoodcubeConfiguratorProps> = ({ vari
                 
                 {/* Cladding Key second */}
                 <div className="transition-all duration-300 ease-in-out">
-                  <CladdingKey requirements={requirements} showDebug={debugMode} />
+                  <CladdingKey requirements={requirements} prices={prices} showDebug={debugMode} />
                 </div>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- show price-based subtotal in CladdingKey
- compute price values in FoodcubeConfigurator and pass them to CladdingKey

## Testing
- `npx tsc --noEmit`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685a5bd2fea48330b653dd569f3fee5b