### PR TITLE
Replace floating bubble with bar

### DIFF
--- a/src/components/FoodcubeConfigurator.tsx
+++ b/src/components/FoodcubeConfigurator.tsx
@@ -37,38 +37,19 @@ const FloatingActionButtons = ({
   };
   
   return createPortal(
-    <div className="fixed z-[100000000001] bottom-6 right-6 flex flex-col items-end gap-4" style={{ position: 'fixed', pointerEvents: 'auto' }}>
+    <div
+      className="fixed z-[100000000001] bottom-6 left-6 right-6 flex flex-col items-center gap-4"
+      style={{ pointerEvents: 'auto' }}
+    >
       {/* Apply button */}
       <button
         onClick={onApply}
-        className="flex flex-col items-center justify-center w-44 h-44 rounded-full bg-gradient-to-br from-blue-400 via-blue-600 to-blue-700 text-white font-bold shadow-2xl border-4 border-white hover:bg-blue-700 transition-all transform hover:scale-105 relative"
-        style={{ 
-          background: `linear-gradient(135deg, ${PANEL_COLORS.left}DD, ${PANEL_COLORS.left}, ${PANEL_COLORS.left}99)`, 
-          boxShadow: '0 10px 35px -5px rgba(18, 159, 206, 0.6), 0 10px 20px -6px rgba(18, 159, 206, 0.4)'
-        }}
+        className="w-full py-4 rounded-full text-white font-bold shadow-2xl hover:brightness-110 transition-all"
+        style={{ background: PANEL_COLORS.left }}
         data-testid="mobile-apply-button"
-        aria-label="Select products"
+        aria-label="Add layout to kit"
       >
-        {/* Arrow indicator */}
-        <div className="absolute -top-7 left-1/2 transform -translate-x-1/2 bg-yellow-400 text-blue-900 px-4 py-1.5 rounded-full text-sm font-bold shadow-md animate-pulse flex items-center gap-1">
-          <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
-            <line x1="12" y1="5" x2="12" y2="19"></line>
-            <polyline points="19 12 12 19 5 12"></polyline>
-          </svg>
-          TAP HERE
-        </div>
-        
-        <div className="flex flex-col items-center justify-center leading-none">
-          {/* <svg xmlns="http://www.w3.org/2000/svg" width="36" height="36" viewBox="0 0 24 24" fill="none" stroke="white" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="mb-2">
-            <path d="M20 6L9 17l-5-5"></path>
-          </svg> */}
-          <span className="text-lg font-extrabold mb-2 uppercase tracking-wide text-white">SELECT<br />& CLOSE</span>
-          <div className="bg-white/30 px-4 py-2 rounded-full">
-            <span className="text-2xl font-black text-white">{requirementsSum}</span>
-            <span className="text-base ml-1 text-white">packs</span>
-          </div>
-          {/* <span className="text-sm mt-3 opacity-90 font-medium text-white semibold">Tap to complete</span> */}
-        </div>
+        Add Layout to Kit ({requirementsSum} packs)
       </button>
       
       {/* Clear button */}


### PR DESCRIPTION
## Summary
- show a full-width `Add Layout to Kit` bar instead of floating bubble

## Testing
- `npx tsc -p tsconfig.app.json --noEmit` *(fails: many errors)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685a5bb8e490833083d9366920d252ad

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Simplified and repositioned the floating action buttons for a cleaner, bottom-centered layout.
  * Updated the "Apply" button to a more streamlined, full-width design with a solid background and improved hover effect.

* **Accessibility**
  * Changed the button’s aria-label for clearer description.

* **User Interface**
  * Replaced the previous animated and multi-element button label with a single, clear text: "Add Layout to Kit ({requirementsSum} packs)."

<!-- end of auto-generated comment: release notes by coderabbit.ai -->